### PR TITLE
Update setHeadlessWhen.js

### DIFF
--- a/hooks/setHeadlessWhen.js
+++ b/hooks/setHeadlessWhen.js
@@ -25,7 +25,12 @@ module.exports = function(when) {
           cfg.helpers.WebDriver.desiredCapabilities || {},
           {
             chromeOptions: {
-              args: [ "--headless", "--disable-gpu", "--no-sandbox" ]
+              args: [ 
+                "--headless",
+                // Use --disable-gpu to avoid an error from a missing Mesa library, as per
+                // https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md
+                "--disable-gpu"
+              ]
             }
           }
         )


### PR DESCRIPTION
Headless mode has nothing to do with chrome sandbox, I would remove it. When required a special hook "setSandboxedWhen" would better fit. 

Added also a comment reference why --disable-gpu is required (copied from https://stackoverflow.com/questions/42303119/selenium-webdriverio-chrome-headless )