### PR TITLE
Specify peer dependency on codeceptjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "mocha": "^8.2.1",
     "puppeteer": "^2.1",
     "webdriverio": "^6.4.2"
+  },
+  "peerDependencies": {
+    "codeceptjs": ">= 2.3.3"
   }
 }


### PR DESCRIPTION
same issue as https://github.com/codeceptjs/CodeceptJS/pull/3413

Yarn v3 is stricter on dependencies and doesn't allow you to require non listed deps